### PR TITLE
fix dir rplugin, add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # vim-voice-control
+
 A neovim plugin to control vim with voice
+
+## Installation
+
+Install the needed packages:
+
+```bash
+sudo apt-get install portaudio19-dev
+pip3 install pyaudio SpeechRecognition openai-whisper
+```
+
+Install using your favourite plugin manager:
+
+```vimscript
+Plug '~/code/vimplugins/vim-voice-control', {'do': ':UpdateRemotePlugins'}
+```
+
+## Usage
+
+TODO explain `:Vvc` and `:VvcMode`

--- a/rplugin/python3/voice-control.py
+++ b/rplugin/python3/voice-control.py
@@ -7,12 +7,11 @@ import pynvim
 import speech_recognition as sr
 import yaml
 
-BASE_DIR = Path(__file__).parents[1]
-DATA_DIR = BASE_DIR / 'data'
+BASE_DIR = Path(__file__).parents[2]
+DATA_DIR = BASE_DIR / "data"
 
 
 class InvalidCommand(Exception):
-
     def __init__(self, cmd):
         self.cmd = cmd
 
@@ -23,16 +22,16 @@ class InvalidCommand(Exception):
 class NvimAPI:
 
     REG_UNNAMED = '"'
-    REG_SMALL_DELETE = '-'
-    REG_COMMAND = ':'
-    REG_INSERT = '.'
-    REG_FILE = '%'
-    REG_ALTERNATE_BUFFER = '#'
-    REG_EXPRESSION = '='
-    REG_GUI_SELECTION = '*'
-    REG_GUI_CLIPBOARD = '+'
-    REG_BLACK_HOLE = '_'
-    REG_SEARCH = '/'
+    REG_SMALL_DELETE = "-"
+    REG_COMMAND = ":"
+    REG_INSERT = "."
+    REG_FILE = "%"
+    REG_ALTERNATE_BUFFER = "#"
+    REG_EXPRESSION = "="
+    REG_GUI_SELECTION = "*"
+    REG_GUI_CLIPBOARD = "+"
+    REG_BLACK_HOLE = "_"
+    REG_SEARCH = "/"
 
     def __init__(self, nvim):
         self.nvim = nvim
@@ -44,98 +43,98 @@ class NvimAPI:
         self.nvim.err_write(msg + "\n")
 
     def goto_line(self, lineno):
-        self.nvim.feedkeys(f'{lineno}gg')
+        self.nvim.feedkeys(f"{lineno}gg")
 
     def select_lines(self, start, end=None):
         start = int(start)
-        keys = f'{start}ggV'
+        keys = f"{start}ggV"
         if end is not None:
             end = int(end)
-            keys += f'{end}gg'
+            keys += f"{end}gg"
         self.nvim.feedkeys(keys)
 
     def next_tab(self):
-        self.nvim.feedkeys('gt')
+        self.nvim.feedkeys("gt")
 
     def prev_tab(self):
-        self.nvim.feedkeys('gT')
+        self.nvim.feedkeys("gT")
 
     def copy_to_register(self, register=None):
         if register is None:
-            self.nvim.feedkeys('y')
+            self.nvim.feedkeys("y")
         else:
             self.nvim.feedkeys(f'"{register}y')
 
     def paste_from_register(self, register=None, times=None):
-        keys = 'p'
+        keys = "p"
         if register is not None:
             keys = f'"{register}{keys}'
         if times is not None:
-            keys = f'{times}{keys}'
+            keys = f"{times}{keys}"
         self.nvim.feedkeys(keys)
 
 
 REGISTERS_ALIASES = {
-    'main': NvimAPI.REG_UNNAMED,
-    'unnamed': NvimAPI.REG_UNNAMED,
-    'insert': NvimAPI.REG_INSERT,
-    'file': NvimAPI.REG_FILE,
-    'path': NvimAPI.REG_FILE,
-    'current file': NvimAPI.REG_FILE,
-    'current path': NvimAPI.REG_FILE,
-    'command': NvimAPI.REG_COMMAND,
-    'command line': NvimAPI.REG_COMMAND,
-    'last command': NvimAPI.REG_COMMAND,
-    'last command line': NvimAPI.REG_COMMAND,
-    'alternate file': NvimAPI.REG_ALTERNATE_BUFFER,
-    'alternate buffer': NvimAPI.REG_ALTERNATE_BUFFER,
-    'expression': NvimAPI.REG_EXPRESSION,
-    'last expression': NvimAPI.REG_EXPRESSION,
-    'search': NvimAPI.REG_SEARCH,
-    'last search': NvimAPI.REG_SEARCH,
-    'delete': NvimAPI.REG_SMALL_DELETE,
-    'small delete': NvimAPI.REG_SMALL_DELETE,
-    'selection': NvimAPI.REG_GUI_SELECTION,
-    'clipboard': NvimAPI.REG_GUI_CLIPBOARD,
-    'black hole': NvimAPI.REG_BLACK_HOLE,
-    'void': NvimAPI.REG_BLACK_HOLE,
-    'zero': '0',
-    'one': '1',
-    'two': '2',
-    'three': '3',
-    'four': '4',
-    'five': '5',
-    'six': '6',
-    'seven': '7',
-    'eigh': '8',
-    'nine': '9',
-    'first': '1',
-    'second': '2',
-    'third': '3',
-    'fourth': '4',
-    'fifth': '5',
-    'sixth': '6',
-    'seventh': '7',
-    'eighth': '8',
-    'nineth': '9',
+    "main": NvimAPI.REG_UNNAMED,
+    "unnamed": NvimAPI.REG_UNNAMED,
+    "insert": NvimAPI.REG_INSERT,
+    "file": NvimAPI.REG_FILE,
+    "path": NvimAPI.REG_FILE,
+    "current file": NvimAPI.REG_FILE,
+    "current path": NvimAPI.REG_FILE,
+    "command": NvimAPI.REG_COMMAND,
+    "command line": NvimAPI.REG_COMMAND,
+    "last command": NvimAPI.REG_COMMAND,
+    "last command line": NvimAPI.REG_COMMAND,
+    "alternate file": NvimAPI.REG_ALTERNATE_BUFFER,
+    "alternate buffer": NvimAPI.REG_ALTERNATE_BUFFER,
+    "expression": NvimAPI.REG_EXPRESSION,
+    "last expression": NvimAPI.REG_EXPRESSION,
+    "search": NvimAPI.REG_SEARCH,
+    "last search": NvimAPI.REG_SEARCH,
+    "delete": NvimAPI.REG_SMALL_DELETE,
+    "small delete": NvimAPI.REG_SMALL_DELETE,
+    "selection": NvimAPI.REG_GUI_SELECTION,
+    "clipboard": NvimAPI.REG_GUI_CLIPBOARD,
+    "black hole": NvimAPI.REG_BLACK_HOLE,
+    "void": NvimAPI.REG_BLACK_HOLE,
+    "zero": "0",
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7",
+    "eigh": "8",
+    "nine": "9",
+    "first": "1",
+    "second": "2",
+    "third": "3",
+    "fourth": "4",
+    "fifth": "5",
+    "sixth": "6",
+    "seventh": "7",
+    "eighth": "8",
+    "nineth": "9",
 }
 
 
 TYPE_TO_REGEX = {
-    'UINT': r'\d+',
-    'INT': r'-?\d+',
-    'ID': '.+',
-    'PATH': '.+',
-    'REG': '.+',
+    "UINT": r"\d+",
+    "INT": r"-?\d+",
+    "ID": ".+",
+    "PATH": ".+",
+    "REG": ".+",
 }
 
 
 TYPE_CONVERSION = {
-    'UINT': int,
-    'INT': int,
-    'ID': lambda x: re.sub('\s+', '_', x),
-    'PATH': lambda x: re.sub('\s+', '/', x),
-    'REG': lambda x: REGISTERS_ALIASES.get(x.lower(), x)[0]
+    "UINT": int,
+    "INT": int,
+    "ID": lambda x: re.sub("\s+", "_", x),
+    "PATH": lambda x: re.sub("\s+", "/", x),
+    "REG": lambda x: REGISTERS_ALIASES.get(x.lower(), x)[0],
 }
 
 
@@ -143,7 +142,8 @@ def param_to_regex(i, argtypes):
     def replacer(m):
         arg_name = m[1]
         regex = TYPE_TO_REGEX[argtypes[arg_name]]
-        return f'(?P<{arg_name}_{i}>{regex})'
+        return f"(?P<{arg_name}_{i}>{regex})"
+
     return replacer
 
 
@@ -160,11 +160,11 @@ class VoiceControl(NvimAPI):
         self.re_commands = self.get_re_commands()
 
     def get_re_commands(self):
-        with open(DATA_DIR / 'cmd-to-nl.yml') as f:
+        with open(DATA_DIR / "cmd-to-nl.yml") as f:
             cmd_to_nl = yaml.load(f, Loader=yaml.Loader)
-        variables = cmd_to_nl.pop('vars', {})
+        variables = cmd_to_nl.pop("vars", {})
         for name, values in variables.items():
-            variables[name] = '(' + '|'.join(values) + ')'
+            variables[name] = "(" + "|".join(values) + ")"
         re_commands = []
         for cmd, nl_cmds in cmd_to_nl.items():
             cmd = cmd.split()
@@ -172,22 +172,22 @@ class VoiceControl(NvimAPI):
             cmd_args = []
             argtypes = {}
             for arg in cmd[1:]:
-                if m := re.fullmatch(r'([A-Z]+)\(([a-z])\)', arg):
+                if m := re.fullmatch(r"([A-Z]+)\(([a-z])\)", arg):
                     arg_type = m[1]
                     arg_name = m[2]
                     argtypes[arg_name] = arg_type
                     cmd_args.append((arg_name, TYPE_CONVERSION[arg_type]))
-                elif m := re.fullmatch(r'([A-Z]+)\((.*?)\)', arg):
+                elif m := re.fullmatch(r"([A-Z]+)\((.*?)\)", arg):
                     cmd_args.append((None, TYPE_CONVERSION[m[1]](m[2])))
                 else:
                     raise SyntaxError("Invalid command definition: {cmd}")
             parts = []
             for i, nl_cmd in enumerate(nl_cmds):
-                part = re.sub(r'\b[A-Z_]+\b', lambda m: variables[m[0]], nl_cmd)
-                part = re.sub(r'\{([a-z])\}', param_to_regex(i, argtypes), part)
+                part = re.sub(r"\b[A-Z_]+\b", lambda m: variables[m[0]], nl_cmd)
+                part = re.sub(r"\{([a-z])\}", param_to_regex(i, argtypes), part)
                 parts.append(part)
             re_commands.append(
-                ([cmd_name, *cmd_args], re.compile('(' + '|'.join(parts) + ')', re.I))
+                ([cmd_name, *cmd_args], re.compile("(" + "|".join(parts) + ")", re.I))
             )
         return re_commands
 
@@ -241,7 +241,7 @@ class VoiceControl(NvimAPI):
 
     def execute_command(self, cmd, *args):
         cmd = cmd.lower()
-        handler_names = [f'cmd_{cmd}', cmd]
+        handler_names = [f"cmd_{cmd}", cmd]
         for handler_name in handler_names:
             try:
                 handler = getattr(self, handler_name)
@@ -251,7 +251,7 @@ class VoiceControl(NvimAPI):
                 return handler(*args)
         raise NotImplementedError(f"This command is not yet implemented: {cmd} {args}")
 
-    @pynvim.command('Vvc')
+    @pynvim.command("Vvc")
     def voice_command(self, timeout=5):
         nl_cmd = self.listen(timeout=timeout)
         if nl_cmd is None:
@@ -269,7 +269,7 @@ class VoiceControl(NvimAPI):
         else:
             return True
 
-    @pynvim.command('VvcMode')
+    @pynvim.command("VvcMode")
     def voice_command_mode(self):
         while True:
             try:


### PR DESCRIPTION
I needed to change the directory to rplugin/ - I don't know if remote plugins used to work in other dirs, but that's what the current documentation for python plugins says. I also needed the instructions that I've added to the readme in order to get everything working, installing the right python packages and calling `:UpdateRemotePlugins`.

I also autoformatted the python according to default pylint.